### PR TITLE
remove trailing slash on source directories

### DIFF
--- a/coqproject.sh
+++ b/coqproject.sh
@@ -64,7 +64,7 @@ for dir in ${DIRS[@]}; do
     namespace_var=${namespace_var//-/_}
     namespace_var=${namespace_var//./_}
     namespace=${!namespace_var:="\"\""}
-    LINE="-Q $dir/ $namespace"
+    LINE="-Q $dir $namespace"
     echo $LINE >> $COQPROJECT_TMP
 done
 


### PR DESCRIPTION
This is a fix for windows that seems to also work with UNIX. I'm not sure if the deps traversal also needs this. I don't have a test case to try it out, if there's an example project that I can try, I'm happy to be your windows tester for this change.