### PR TITLE
Unified script version with updated documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ default: Makefile.coq
 Makefile.coq: _CoqProject
 	coq_makefile -f _CoqProject -o Makefile.coq
 
-clean:
+clean: Makefile.coq
 	$(MAKE) -f Makefile.coq clean
 	rm Makefile.coq
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ source script/coqproject.sh
 
 The configure script sources `coqproject.sh` instead of running it so
 that environment variables are handled correctly (bash currently
-doesn't support exporting array variables such as `DIRS` and
+does not support exporting array variables such as `DIRS` and
 `CANARIES`). This script will have to be re-run any time a file is
 added to the project.
 
@@ -89,7 +89,7 @@ the empty namespace, then the configure script should include
 NAMESPACE_A=Foo
 ```
 
-Note that "." can't be part of a variable name, so it's replaced by "_".
+Note that "." cannot be part of a variable name, so it is replaced by "_".
 So, to put the current directory in the namespace `Bar`, set
 ```bash
 NAMESPACE__=Bar

--- a/README.md
+++ b/README.md
@@ -95,9 +95,9 @@ So, to put the current directory in the namespace `Bar`, set
 NAMESPACE__=Bar
 ```
 
-Directories (and subdirectories) of dependencies can also be associated
+Subdirectories of dependencies can also be associated
 with namespaces. For example, if the `lib` subdirectory of `Verdi`
-should be in the `Lib` namespace, set
+should be in the `Lib` namespace instead of `Verdi`, set
 ```bash
 NAMESPACE_Verdi_lib=Lib
 ```

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ A sample `Makefile` is included as well.
 ### External dependencies
 
 The `DEPS` variables is a list of external dependencies for the
-project. For example, the following records depend on the library
+project. For example, the following records a dependency on the library
 `Verdi`:
 
 ```bash
@@ -40,16 +40,17 @@ DEPS=(Verdi)
 ```
 
 Each element of the list names a dependency.  By default, each
-dependency is expected to be found in Coq's `user-contrib` directory.
+dependency is expected to be found in Coq's global `user-contrib` directory.
 To customize this location for a dependency `X`, set the environment
 variable `X_PATH`. For example, if `Verdi` is located in
-`/path/to/Verdi`, then set:
+`/path/to/verdi`, then set:
 
 ```bash
-Verdi_PATH=/path/to/Verdi
+Verdi_PATH=/path/to/verdi
 ```
 
-`coqproject.sh` will exit with error if any dependency is not found.
+`coqproject.sh` will exit with an error if a dependency is not found
+at its indicated path.
 
 
 ### Subdirectories containing Coq files
@@ -92,7 +93,7 @@ NAMESPACE__=Bar
 ```
 
 Directories (and subdirectories) of dependencies can also be associated
-with namespaces. For example, if the `lib` subdirectory of `Verdi`'
+with namespaces. For example, if the `lib` subdirectory of `Verdi`
 should be in the `Lib` namespace, set
 ```bash
 NAMESPACE_Verdi_lib=Lib
@@ -100,10 +101,10 @@ NAMESPACE_Verdi_lib=Lib
 
 ### Report missing dependencies
 
-Some libraries are expected to always be installed globally, e.g.
-`ssreflect`. `coqproject.sh` supports checking for these libraries
-using canaries, which test to see whether a given module can be
-imported.
+Some libraries are expected to always be installed globally in Coq's
+`user-contrib` directory, e.g. `ssreflect`. `coqproject.sh` supports
+checking for these libraries using canaries, which test whether
+a given module can be imported.
 
 The variable `CANARIES` contains a list, conceptually grouped into
 pairs, where the first element of each pair is a module name, and the

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # coqproject.sh
 
-This is a simple script to create a `_CoqProject` file for a
+This is a simple bash script to create a `_CoqProject` file for a
 [Coq](https://coq.inria.fr) development, including external
 dependencies and namespaces. The resulting file should work with
 [`coq_makefile`](https://coq.inria.fr/distrib/current/refman/tools.html#Makefile),

--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
 # coqproject.sh
 
-This is a simple script to create a `_CoqProject` file for a Coq
-development, including external dependencies and namespaces. The
-resulting file should work with `coq_makefile`, Proof General, and
-CoqIde. Users can set environment variables to configure the paths to
+This is a simple script to create a `_CoqProject` file for a
+[Coq](https://coq.inria.fr) development, including external
+dependencies and namespaces. The resulting file should work with
+[`coq_makefile`](https://coq.inria.fr/distrib/current/refman/tools.html#Makefile),
+[Proof General](https://proofgeneral.github.io), and
+[CoqIDE](https://coq.inria.fr/distrib/current/refman/coqide.html).
+Users can set environment variables to configure the paths to
 external dependencies; see below for more details.
 
 ## Getting Started

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ like this:
 
 ```bash
 DIRS=(theories)
-CANARIES=("mathcomp.ssreflect.ssreflect", "Ssreflect required")
+CANARIES=("mathcomp.ssreflect.ssreflect" "Ssreflect missing")
 source script/coqproject.sh
 ```
 
@@ -33,20 +33,20 @@ A sample `Makefile` is included as well.
 
 The `DEPS` variables is a list of external dependencies for the
 project. For example, the following records depend on the library
-`StructTact`:
+`Verdi`:
 
-```
-DEPS=(StructTact)
+```bash
+DEPS=(Verdi)
 ```
 
 Each element of the list names a dependency.  By default, each
-dependency is expected to be found in the parent directory.  To
-customize this location for a dependency `X`, set the environment
-variable `X_PATH`. For example, if `StructTact` is located in
-`/path/to/StructTact`, then set
+dependency is expected to be found in Coq's `user-contrib` directory.
+To customize this location for a dependency `X`, set the environment
+variable `X_PATH`. For example, if `Verdi` is located in
+`/path/to/Verdi`, then set:
 
-```
-StructTact_PATH=/path/to
+```bash
+Verdi_PATH=/path/to/Verdi
 ```
 
 `coqproject.sh` will exit with error if any dependency is not found.
@@ -62,10 +62,18 @@ in that directory for source files.
 
 For example, if a project contains two subdirectories `A` and `B`,
 then setting
-```
+```bash
 DIRS=(A B)
 ```
 will do the right thing.
+
+Dependencies in the `DEPS` variable can also be associated with
+subdirectories. For example, if the dependency `Verdi` has
+subdirectories `core` and `lib`, setting
+```bash
+Verdi_DIRS=(core lib)
+```
+will reflect this.
 
 By default, files from all directories are put in the empty namespace,
 but this can be customized by setting the `NAMESPACE_X` variable.
@@ -73,19 +81,26 @@ but this can be customized by setting the `NAMESPACE_X` variable.
 For example, if the project imports modules from the `A` subdirectory
 with namespace `Foo`, but imports modules from the `B` subdirectory with
 the empty namespace, then the configure script should include
-```
+```bash
 NAMESPACE_A=Foo
 ```
 
 Note that "." can't be part of a variable name, so it's replaced by "_".
 So, to put the current directory in the namespace `Bar`, set
-```
+```bash
 NAMESPACE__=Bar
+```
+
+Directories (and subdirectories) of dependencies can also be associated
+with namespaces. For example, if the `lib` subdirectory of `Verdi`'
+should be in the `Lib` namespace, set
+```bash
+NAMESPACE_Verdi_lib=Lib
 ```
 
 ### Report missing dependencies
 
-Some libraries are expected to be installed globally, e.g.
+Some libraries are expected to always be installed globally, e.g.
 `ssreflect`. `coqproject.sh` supports checking for these libraries
 using canaries, which test to see whether a given module can be
 imported.
@@ -96,7 +111,7 @@ second element is a message to print if the module fails to import.
 
 For example, if a project depends on `ssreflect` being globally
 installed, setting
-```
+```bash
 CANARIES=("mathcomp.ssreflect.ssreflect" "Ssreflect missing")
 ```
 will try to import `mathcomp.ssreflect.ssreflect` and report an error
@@ -112,7 +127,7 @@ added to `_CoqProject`.
 
 For example, if a project automatically generates a file `Foo.v` that
 is not present at configure time, then including
-```
+```bash
 EXTRA=(GeneratedFile.v)
 ```
 will ensure that `coq_makefile` knows about this file.

--- a/README.md
+++ b/README.md
@@ -121,6 +121,16 @@ CANARIES=("mathcomp.ssreflect.ssreflect" "Ssreflect missing")
 will try to import `mathcomp.ssreflect.ssreflect` and report an error
 if it is not found.
 
+### Extra arguments
+
+Projects depending on libraries like `ssreflect` may want
+ignore certain warnings during proof checking, e.g.,
+"notation overridden". Such directives can be declared in
+the `ARG` variable, as in
+```bash
+ARG="-w -notation-overridden"
+```
+
 ### Extra files
 
 `coqproject.sh` works by searching for `.v` files in every directory

--- a/coqproject.sh
+++ b/coqproject.sh
@@ -74,6 +74,10 @@ for dir in ${DIRS[@]}; do
     echo $LINE >> $COQPROJECT_TMP
 done
 
+if [ ! "x${ARG}" = "x" ]; then
+    echo "-arg \"${ARG}\"" >> $COQPROJECT_TMP
+fi
+
 for dir in ${DIRS[@]}; do
     echo >> $COQPROJECT_TMP
     find $dir -iname '*.v' -not -name '*\#*'  >> $COQPROJECT_TMP

--- a/coqproject.sh
+++ b/coqproject.sh
@@ -86,5 +86,4 @@ for extra in ${EXTRA[@]}; do
     fi
 done
 
-
 mv $COQPROJECT_TMP _CoqProject

--- a/coqproject.sh
+++ b/coqproject.sh
@@ -3,7 +3,7 @@
 ### coqproject.sh
 ### Creates a _CoqProject file, including external dependencies.
 
-### See README.md for a description.
+### See the coqproject.sh README.md file for a description.
 
 ## Implementation
 
@@ -24,24 +24,30 @@ function dep_dirs_lines(){
       namespace_var=${namespace_var//-/_}
       namespace_var=${namespace_var//./_}
       namespace=${!namespace_var:=$2}
-      LINE="-Q $1/$dep_dir/ $namespace"
+      if [ $dep_dir = "." ]; then
+        LINE="-Q $1 $namespace"
+      else
+        LINE="-Q $1/$dep_dir $namespace"
+      fi
       echo $LINE >> $COQPROJECT_TMP
   done
 }
 for dep in ${DEPS[@]}; do
     path_var="$dep"_PATH
-    path=${!path_var:="../$dep"}
-    if [ ! -d "$path" ]; then
-        echo "$dep not found at $path."
-        exit 1
+    if [ ! "x${!path_var}" = "x" ]; then
+	path=${!path_var}
+	if [ ! -d "$path" ]; then
+            echo "$dep not found at $path."
+            exit 1
+	fi
+
+	pushd "$path" > /dev/null
+	path=$(pwd)
+	popd > /dev/null
+	echo "$dep found at $path"
+
+	dep_dirs_lines $path $dep
     fi
-
-    pushd "$path" > /dev/null
-    path=$(pwd)
-    popd > /dev/null
-    echo "$dep found at $path"
-
-    dep_dirs_lines $path $dep
 done
 
 COQTOP="coqtop $(cat $COQPROJECT_TMP)"
@@ -63,8 +69,8 @@ for dir in ${DIRS[@]}; do
     namespace_var=${namespace_var//\//_}
     namespace_var=${namespace_var//-/_}
     namespace_var=${namespace_var//./_}
-    namespace=${!namespace_var:="\"\""}
-    LINE="-Q $dir/ $namespace"
+    namespace=${!namespace_var:="''"}
+    LINE="-Q $dir $namespace"
     echo $LINE >> $COQPROJECT_TMP
 done
 

--- a/coqproject.sh
+++ b/coqproject.sh
@@ -3,7 +3,7 @@
 ### coqproject.sh
 ### Creates a _CoqProject file, including external dependencies.
 
-### See the coqproject.sh README.md file for a description.
+### See the README.md file for a description.
 
 ## Implementation
 


### PR DESCRIPTION
One important change is that dependencies in `DEPS` do not have a default directory (such as `../verdi`). This is primarily to allow dependencies to be installed globally via OPAM packages. 

Another change is that the empty namespace must be `''` to be compatible with `coq_makefile` in Coq 8.7.0. However, this currently makes the resulting `_CoqProject` file incompatible with both ProofGeneral and CoqIDE.